### PR TITLE
Enhancement/strict errors

### DIFF
--- a/src/ash/Dictionary.ts
+++ b/src/ash/Dictionary.ts
@@ -25,7 +25,7 @@ export class Dictionary<TKey, TValue>
         return value;
     }
 
-    public get( key:TKey ):TValue
+    public get( key:TKey ):TValue | null
     {
         let index = this._keys.indexOf( key );
         if( index < 0 )
@@ -43,7 +43,7 @@ export class Dictionary<TKey, TValue>
         return !(this._keys.indexOf( key ) < 0);
     }
 
-    public remove( key:TKey ):TValue
+    public remove( key:TKey ):TValue | null
     {
         let index = this._keys.indexOf( key );
         if( index < 0 )

--- a/src/ash/core/ComponentMatchingFamily.ts
+++ b/src/ash/core/ComponentMatchingFamily.ts
@@ -16,11 +16,11 @@ import { ClassType } from '../Types';
  */
 export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily<TNode>
 {
-    private nodes:NodeList<TNode>;
-    private entities:Dictionary<Entity, TNode>;
+    private nodes!:NodeList<TNode>;
+    private entities!:Dictionary<Entity, TNode>;
     private nodeClass:{ new():TNode };
-    public components:Dictionary<ClassType<any>, string>;
-    private nodePool:NodePool<TNode>;
+    public components!:Dictionary<ClassType<any>, string>;
+    private nodePool!:NodePool<TNode>;
     private engine:Engine;
 
     /**
@@ -51,7 +51,7 @@ export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily
         let dummyNode:TNode = this.nodePool.get();
         this.nodePool.dispose( dummyNode );
 
-        let types = dummyNode.constructor[ '__ash_types__' ];
+        let types = (<any>dummyNode.constructor)[ '__ash_types__' ];
 
         for( let type in types )
         {
@@ -132,7 +132,9 @@ export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily
             node.entity = entity;
             for( let componentClass of this.components.keys() )
             {
-                node[ this.components.get( componentClass ) ] = entity.get( componentClass );
+                let cmp = this.components.get( componentClass );
+                if (cmp)
+                    (<any>node)[ cmp ] = entity.get( componentClass );
             }
 
             this.entities.set( entity, node );
@@ -147,7 +149,7 @@ export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily
     {
         if( this.entities.has( entity ) )
         {
-            let node:TNode = this.entities.get( entity );
+            let node:TNode = this.entities.get( entity )!;
             this.entities.remove( entity );
             this.nodes.remove( node );
             if( this.engine.updating )
@@ -176,7 +178,7 @@ export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily
      */
     public cleanUp():void
     {
-        for( let node:Node<TNode> = this.nodes.head; node; node = node.next )
+        for( let node:Node<TNode> | null = this.nodes.head; node; node = node.next )
         {
             this.entities.remove( node.entity );
         }

--- a/src/ash/core/ComponentMatchingFamily.ts
+++ b/src/ash/core/ComponentMatchingFamily.ts
@@ -132,9 +132,7 @@ export class ComponentMatchingFamily<TNode extends Node<any>> implements IFamily
             node.entity = entity;
             for( let componentClass of this.components.keys() )
             {
-                let cmp = this.components.get( componentClass );
-                if (cmp)
-                    (<any>node)[ cmp ] = entity.get( componentClass );
+                (<any>node)[ this.components.get( componentClass )! ] = entity.get( componentClass );
             }
 
             this.entities.set( entity, node );

--- a/src/ash/core/Engine.ts
+++ b/src/ash/core/Engine.ts
@@ -17,9 +17,7 @@ import { ClassType } from '../Types';
  */
 export class Engine
 {
-
-
-    private entityNames:Map<string, Entity>;
+    private entityNames:{[key:string]:Entity | null};
     private entityList:EntityList;
     private systemList:SystemList;
     private families:Dictionary<{ new():Node<any> }, IFamily<any>>;
@@ -48,7 +46,7 @@ export class Engine
     constructor()
     {
         this.entityList = new EntityList();
-        this.entityNames = new Map();
+        this.entityNames = {};
         this.systemList = new SystemList();
         this.families = new Dictionary<{ new():Node<any> }, IFamily<any>>();
         this.updateComplete = new Signal0();
@@ -61,12 +59,12 @@ export class Engine
      */
     public addEntity( entity:Entity ):void
     {
-        if( this.entityNames.has(entity.name) )
+        if( this.entityNames[ entity.name ] )
         {
             throw new Error( 'The entity name ' + entity.name + ' is already in use by another entity.' );
         }
         this.entityList.add( entity );
-        this.entityNames.set( entity.name, entity) ;
+        this.entityNames[ entity.name ] = entity;
         entity.componentAdded.add( this.componentAdded );
         entity.componentRemoved.add( this.componentRemoved );
         entity.nameChanged.add( this.entityNameChanged );
@@ -90,15 +88,15 @@ export class Engine
         {
             family.removeEntity( entity );
         }
-        this.entityNames.delete(entity.name);
+        this.entityNames[ entity.name ] = null;
         this.entityList.remove( entity );
     }
 
     private entityNameChanged = ( entity:Entity, oldName:string ) => {
-        if( this.entityNames.get(oldName) === entity )
+        if( this.entityNames[ oldName ] === entity )
         {
-            this.entityNames.delete(oldName);
-            this.entityNames.set( entity.name, entity) ;
+            this.entityNames[ oldName ] = null;
+            this.entityNames[ entity.name ] = entity;
         }
     };
 
@@ -108,9 +106,9 @@ export class Engine
      * @param name The name of the entity
      * @return The entity, or null if no entity with that name exists on the engine
      */
-    public getEntityByName( name:string ):Entity
+    public getEntityByName( name:string ):Entity | null
     {
-        return this.entityNames.get(name);
+        return this.entityNames[ name ];
     }
 
     /**

--- a/src/ash/core/Entity.ts
+++ b/src/ash/core/Entity.ts
@@ -41,8 +41,8 @@ export class Entity
      */
     public nameChanged:Signal2<Entity, string>;
 
-    public previous:Entity;
-    public next:Entity;
+    public previous:Entity | null = null;
+    public next:Entity | null = null;
     public components:Dictionary<ClassType<any>, any>;
 
     /**
@@ -101,20 +101,20 @@ export class Entity
      *     .add( new Display( new PlayerClip() );</code>
      */
 
-    public add<T>( component:T, componentClass:ClassType<T> = null ):this
+    public add<T>( component:T, componentClass:ClassType<T> | null = null ):this
     {
         if( !componentClass )
         {
             componentClass = component.constructor.prototype.constructor; // weird but works!
         }
 
-        if( this.components.has( componentClass ) )
+        if( this.components.has( componentClass! ) )
         {
-            this.remove( componentClass );
+            this.remove( componentClass! );
         }
 
-        this.components.set( componentClass, component );
-        this.componentAdded.dispatch( this, componentClass );
+        this.components.set( componentClass!, component );
+        this.componentAdded.dispatch( this, componentClass! );
         return this;
     }
 
@@ -124,7 +124,7 @@ export class Entity
      * @param componentClass The class of the component to be removed.
      * @return the component, or null if the component doesn't exist in the entity
      */
-    public remove<T>( componentClass:ClassType<T> ):T
+    public remove<T>( componentClass:ClassType<T> ):T | null
     {
         let component:any = this.components.get( componentClass );
         if( component )

--- a/src/ash/core/EntityList.ts
+++ b/src/ash/core/EntityList.ts
@@ -6,8 +6,8 @@ import { Entity } from './Entity';
  */
 export class EntityList
 {
-    public head:Entity;
-    public tail:Entity;
+    public head:Entity | null = null;
+    public tail:Entity | null = null;
 
     public add( entity:Entity ):void
     {
@@ -18,7 +18,7 @@ export class EntityList
         }
         else
         {
-            this.tail.next = entity;
+            this.tail!.next = entity;
             entity.previous = this.tail;
             entity.next = null;
             this.tail = entity;

--- a/src/ash/core/Node.ts
+++ b/src/ash/core/Node.ts
@@ -15,17 +15,17 @@ export class Node<TNode>
     /**
      * The entity whose components are included in the node.
      */
-    public entity:Entity = null;
+    public entity!:Entity;
 
     /**
      * Used by the NodeList class. The previous node in a node list.
      */
-    public previous:TNode = null;
+    public previous:TNode | null = null;
 
     /**
      * Used by the NodeList class. The next node in a node list.
      */
-    public next:TNode = null;
+    public next:TNode | null = null;
 }
 
 export function keep( type:ClassType<any> ):Function
@@ -36,7 +36,7 @@ export function keep( type:ClassType<any> ):Function
         let ashProp:string = '__ash_types__';
         if( ctor.hasOwnProperty( ashProp ) )
         {
-            map = ctor[ ashProp ];
+            map = (<any>ctor)[ ashProp ];
         }
         else
         {
@@ -47,7 +47,7 @@ export function keep( type:ClassType<any> ):Function
             } );
         }
 
-        map[ propertyKey ] = type;
+        (<any>map)[ propertyKey ] = type;
 
         return descriptor;
     };

--- a/src/ash/core/NodeList.ts
+++ b/src/ash/core/NodeList.ts
@@ -23,11 +23,11 @@ export class NodeList<TNode extends Node<any>>
     /**
      * The first item in the node list, or null if the list contains no nodes.
      */
-    public head:TNode;
+    public head:TNode | null = null;
     /**
      * The last item in the node list, or null if the list contains no nodes.
      */
-    public tail:TNode;
+    public tail:TNode | null = null;
 
     /**
      * A signal that is dispatched whenever a node is added to the node list.
@@ -57,7 +57,7 @@ export class NodeList<TNode extends Node<any>>
         }
         else
         {
-            this.tail.next = node;
+            this.tail!.next = node;
             node.previous = this.tail;
             node.next = null;
             this.tail = node;
@@ -193,7 +193,7 @@ export class NodeList<TNode extends Node<any>>
         {
             return;
         }
-        let remains:TNode = this.head.next;
+        let remains:TNode = this.head!.next;
         for( let node:TNode = remains; node; node = remains )
         {
             let other:TNode;
@@ -238,7 +238,7 @@ export class NodeList<TNode extends Node<any>>
                 }
                 // insert at head
                 node.next = this.head;
-                this.head.previous = node;
+                this.head!.previous = node;
                 node.previous = null;
                 this.head = node;
             }
@@ -266,7 +266,7 @@ export class NodeList<TNode extends Node<any>>
         }
         let lists:TNode[] = [];
         // disassemble the list
-        let start:TNode = this.head;
+        let start:TNode | null = this.head;
         let end:TNode;
         while( start )
         {
@@ -283,13 +283,13 @@ export class NodeList<TNode extends Node<any>>
         // reassemble it in order
         while( lists.length > 1 )
         {
-            lists.push( this.merge( lists.shift(), lists.shift(), sortFunction ) );
+            lists.push( this.merge( lists.shift()!, lists.shift()!, sortFunction ) );
         }
         // find the tail
         this.tail = this.head = lists[ 0 ];
-        while( this.tail.next )
+        while( this.tail!.next )
         {
-            this.tail = this.tail.next;
+            this.tail = this.tail!.next;
         }
     }
 

--- a/src/ash/core/NodePool.ts
+++ b/src/ash/core/NodePool.ts
@@ -12,9 +12,9 @@ import { ClassType } from '../Types';
  */
 export class NodePool<TNode extends Node<any>>
 {
-    private tail:TNode;
+    private tail:TNode | null = null;
     private nodeClass:{ new():TNode };
-    private cacheTail:TNode;
+    private cacheTail:TNode | null = null;
     private components:Dictionary<ClassType<any>, string>;
 
     /**
@@ -51,9 +51,9 @@ export class NodePool<TNode extends Node<any>>
     {
         for( let val of this.components.values() )
         {
-            node[ val ] = null;
+            (<any>node)[ val ] = null;
         }
-        node.entity = null;
+        (<any>node.entity) = null;
 
         node.next = null;
         node.previous = this.tail;

--- a/src/ash/core/System.ts
+++ b/src/ash/core/System.ts
@@ -13,15 +13,15 @@ import { Engine } from './Engine';
  * that match the node.</p>
  */
 export abstract class System
-{
+{   
     /**
      * Used internally to manage the list of systems within the engine. The previous system in the list.
      */
-    public previous:System;
+    public previous:System | null = null;
     /**
      * Used internally to manage the list of systems within the engine. The next system in the list.
      */
-    public next:System;
+    public next:System | null = null;
     /**
      * Used internally to hold the priority of this system within the system list. This is
      * used to order the systems so they are updated in the correct order.

--- a/src/ash/core/System.ts
+++ b/src/ash/core/System.ts
@@ -13,7 +13,7 @@ import { Engine } from './Engine';
  * that match the node.</p>
  */
 export abstract class System
-{   
+{
     /**
      * Used internally to manage the list of systems within the engine. The previous system in the list.
      */

--- a/src/ash/core/SystemList.ts
+++ b/src/ash/core/SystemList.ts
@@ -5,8 +5,8 @@ import { System } from './System';
  */
 export class SystemList
 {
-    public head:System;
-    public tail:System;
+    public head:System | null = null;
+    public tail:System | null = null;
 
     public add( system:System ):void
     {
@@ -17,7 +17,7 @@ export class SystemList
         }
         else
         {
-            let node:System;
+            let node:System | null;
             for( node = this.tail; node; node = node.previous )
             {
                 if( node.priority <= system.priority )
@@ -27,7 +27,7 @@ export class SystemList
             }
             if( node === this.tail )
             {
-                this.tail.next = system;
+                this.tail!.next = system;
                 system.previous = this.tail;
                 system.next = null;
                 this.tail = system;
@@ -43,7 +43,7 @@ export class SystemList
             {
                 system.next = node.next;
                 system.previous = node;
-                node.next.previous = system;
+                node.next!.previous = system;
                 node.next = system;
             }
         }
@@ -85,9 +85,9 @@ export class SystemList
         this.tail = null;
     }
 
-    public get<TSystem extends System>( type:{ new( ...args:any[] ):TSystem } ):TSystem
+    public get<TSystem extends System>( type:{ new( ...args:any[] ):TSystem } ):TSystem | null
     {
-        for( let system:System = this.head; system; system = system.next )
+        for( let system:System | null = this.head; system; system = system.next )
         {
             if( system instanceof type )
             {

--- a/src/ash/fsm/ComponentSingletonProvider.ts
+++ b/src/ash/fsm/ComponentSingletonProvider.ts
@@ -7,7 +7,7 @@ import { IComponentProvider } from './IComponentProvider';
 export class ComponentSingletonProvider<TComponent> implements IComponentProvider<TComponent>
 {
     private componentType:{ new( ...args:any[] ):TComponent };
-    private instance:TComponent;
+    private instance?:TComponent;
 
     /**
      * Constructor

--- a/src/ash/fsm/EngineStateMachine.ts
+++ b/src/ash/fsm/EngineStateMachine.ts
@@ -10,7 +10,7 @@ import { Engine } from '../core/Engine';
 export class EngineStateMachine
 {
     public engine:Engine;
-    private states:Map<string, EngineState>;
+    private states:{[key:string]:EngineState};
     private currentState?:EngineState;
 
     /**
@@ -19,7 +19,7 @@ export class EngineStateMachine
     constructor( engine:Engine )
     {
         this.engine = engine;
-        this.states = new Map();
+        this.states = {};
     }
 
     /**
@@ -31,7 +31,7 @@ export class EngineStateMachine
      */
     public addState( name:string, state:EngineState ):this
     {
-        this.states.set(name, state);
+        this.states[ name ] = state;
         return this;
     }
 
@@ -45,7 +45,7 @@ export class EngineStateMachine
     public createState( name:string ):EngineState
     {
         let state:EngineState = new EngineState();
-        this.states.set(name, state);
+        this.states[ name ] = state;
         return state;
     }
 
@@ -57,7 +57,7 @@ export class EngineStateMachine
      */
     public changeState( name:string ):void
     {
-        let newState:EngineState | null = this.states.get(name);
+        let newState:EngineState | null = this.states[ name ];
         if( !newState )
         {
             throw( new Error( `Engine state ${name} doesn't exist` ) );

--- a/src/ash/fsm/EngineStateMachine.ts
+++ b/src/ash/fsm/EngineStateMachine.ts
@@ -10,8 +10,8 @@ import { Engine } from '../core/Engine';
 export class EngineStateMachine
 {
     public engine:Engine;
-    private states:EngineState[];
-    private currentState:EngineState;
+    private states:Map<string, EngineState>;
+    private currentState?:EngineState;
 
     /**
      * Constructor. Creates an SystemStateMachine.
@@ -19,7 +19,7 @@ export class EngineStateMachine
     constructor( engine:Engine )
     {
         this.engine = engine;
-        this.states = [];
+        this.states = new Map();
     }
 
     /**
@@ -31,7 +31,7 @@ export class EngineStateMachine
      */
     public addState( name:string, state:EngineState ):this
     {
-        this.states[ name ] = state;
+        this.states.set(name, state);
         return this;
     }
 
@@ -45,7 +45,7 @@ export class EngineStateMachine
     public createState( name:string ):EngineState
     {
         let state:EngineState = new EngineState();
-        this.states[ name ] = state;
+        this.states.set(name, state);
         return state;
     }
 
@@ -57,7 +57,7 @@ export class EngineStateMachine
      */
     public changeState( name:string ):void
     {
-        let newState:EngineState = this.states[ name ];
+        let newState:EngineState | null = this.states.get(name);
         if( !newState )
         {
             throw( new Error( `Engine state ${name} doesn't exist` ) );

--- a/src/ash/fsm/EntityState.ts
+++ b/src/ash/fsm/EntityState.ts
@@ -32,7 +32,7 @@ export class EntityState
      * @param type The type of component to get the provider for
      * @return The ComponentProvider
      */
-    public get<TComponent>( type:ClassType<TComponent> ):IComponentProvider<TComponent>
+    public get<TComponent>( type:ClassType<TComponent> ):IComponentProvider<TComponent> | null
     {
         return this.providers.get( type );
     }

--- a/src/ash/fsm/EntityStateMachine.ts
+++ b/src/ash/fsm/EntityStateMachine.ts
@@ -11,7 +11,7 @@ import { ClassType } from '../Types';
  */
 export class EntityStateMachine
 {
-    private states:Map<string, EntityState>;
+    private states:{[key:string]: EntityState}
     /**
      * The current state of the state machine.
      */
@@ -27,7 +27,7 @@ export class EntityStateMachine
     constructor( entity:Entity )
     {
         this.entity = entity;
-        this.states = new Map();
+        this.states = {};
     }
 
     /**
@@ -39,7 +39,7 @@ export class EntityStateMachine
      */
     public addState( name:string, state:EntityState ):this
     {
-        this.states.set(name, state);
+        this.states[ name ] = state;
         return this;
     }
 
@@ -53,7 +53,7 @@ export class EntityStateMachine
     public createState( name:string ):EntityState
     {
         let state:EntityState = new EntityState();
-        this.states.set(name, state);
+        this.states[ name ] = state;
         return state;
     }
 
@@ -65,7 +65,7 @@ export class EntityStateMachine
      */
     public changeState( name:string ):void
     {
-        let newState:EntityState | null = this.states.get(name);
+        let newState:EntityState | null = this.states[ name ];
         if( !newState )
         {
             throw( new Error( `Entity state ${name} doesn't exist` ) );

--- a/src/ash/fsm/EntityStateMachine.ts
+++ b/src/ash/fsm/EntityStateMachine.ts
@@ -11,11 +11,11 @@ import { ClassType } from '../Types';
  */
 export class EntityStateMachine
 {
-    private states:EntityState[];
+    private states:Map<string, EntityState>;
     /**
      * The current state of the state machine.
      */
-    private currentState:EntityState;
+    private currentState?:EntityState;
     /**
      * The entity whose state machine this is
      */
@@ -27,7 +27,7 @@ export class EntityStateMachine
     constructor( entity:Entity )
     {
         this.entity = entity;
-        this.states = [];
+        this.states = new Map();
     }
 
     /**
@@ -39,7 +39,7 @@ export class EntityStateMachine
      */
     public addState( name:string, state:EntityState ):this
     {
-        this.states[ name ] = state;
+        this.states.set(name, state);
         return this;
     }
 
@@ -53,7 +53,7 @@ export class EntityStateMachine
     public createState( name:string ):EntityState
     {
         let state:EntityState = new EntityState();
-        this.states[ name ] = state;
+        this.states.set(name, state);
         return state;
     }
 
@@ -65,7 +65,7 @@ export class EntityStateMachine
      */
     public changeState( name:string ):void
     {
-        let newState:EntityState = this.states[ name ];
+        let newState:EntityState | null = this.states.get(name);
         if( !newState )
         {
             throw( new Error( `Entity state ${name} doesn't exist` ) );
@@ -82,13 +82,13 @@ export class EntityStateMachine
             toAdd = new Dictionary<ClassType<any>, IComponentProvider<any>>();
             for( let type of newState.providers.keys() )
             {
-                toAdd.set( type, newState.providers.get( type ) );
+                toAdd.set( type, newState.providers.get( type )! );
             }
             for( let type of this.currentState.providers.keys() )
             {
-                let other:IComponentProvider<any> = toAdd.get( type );
+                let other:IComponentProvider<any> | null = toAdd.get( type );
 
-                if( other && other.identifier === this.currentState.providers.get( type ).identifier )
+                if( other && other.identifier === this.currentState!.providers.get( type )!.identifier )
                 {
                     toAdd.remove( type );
                 }
@@ -104,7 +104,7 @@ export class EntityStateMachine
         }
         for( let type of toAdd.keys() )
         {
-            this.entity.add( <IComponentProvider<any>>( toAdd.get( type ) ).getComponent(), type );
+            this.entity.add( <IComponentProvider<any>>( toAdd.get( type )! ).getComponent(), type );
         }
         this.currentState = newState;
     }

--- a/src/ash/fsm/StateComponentMapping.ts
+++ b/src/ash/fsm/StateComponentMapping.ts
@@ -12,7 +12,7 @@ export class StateComponentMapping<TComponent>
 {
     private componentType:{ new( ...args:any[] ):TComponent };
     private creatingState:EntityState;
-    private provider:IComponentProvider<TComponent>;
+    private provider!:IComponentProvider<TComponent>;
 
     /**
      * Used internally, the constructor creates a component mapping. The constructor
@@ -66,7 +66,7 @@ export class StateComponentMapping<TComponent>
      * mapping is used.
      * @return This ComponentMapping, so more modifications can be applied
      */
-    public withSingleton( type:{ new( ...args:any[] ):any } = null ):this
+    public withSingleton( type?:{ new( ...args:any[] ):any } ):this
     {
         if( !type )
         {

--- a/src/ash/fsm/SystemSingletonProvider.ts
+++ b/src/ash/fsm/SystemSingletonProvider.ts
@@ -8,7 +8,7 @@ import { ISystemProvider } from './ISystemProvider';
 export class SystemSingletonProvider<TSystem extends System> implements ISystemProvider<TSystem>
 {
     private componentType:{ new( ...args:any[] ):TSystem };
-    private instance:TSystem;
+    private instance?:TSystem;
     private systemPriority:number = 0;
 
     /**

--- a/src/ash/signals/ListenerNode.ts
+++ b/src/ash/signals/ListenerNode.ts
@@ -3,8 +3,8 @@
  */
 export class ListenerNode<TListener>
 {
-    public previous:ListenerNode<TListener>;
-    public next:ListenerNode<TListener>;
-    public listener:TListener;
-    public once:boolean;
+    public previous:ListenerNode<TListener> | null = null;
+    public next:ListenerNode<TListener> | null = null;
+    public listener:TListener | null = null;
+    public once:boolean = false;
 }

--- a/src/ash/signals/ListenerNodePool.ts
+++ b/src/ash/signals/ListenerNodePool.ts
@@ -6,8 +6,8 @@ import { ListenerNode } from './ListenerNode';
  */
 export class ListenerNodePool<TListener>
 {
-    private tail:ListenerNode<TListener>;
-    private cacheTail:ListenerNode<TListener>;
+    private tail:ListenerNode<TListener> | null = null;
+    private cacheTail:ListenerNode<TListener> | null = null;
 
     public get():ListenerNode<TListener>
     {

--- a/src/ash/signals/Signal0.ts
+++ b/src/ash/signals/Signal0.ts
@@ -12,13 +12,13 @@ export class Signal0 extends SignalBase<() => void>
     public dispatch():void
     {
         this.startDispatch();
-        let node:ListenerNode<() => void>;
+        let node:ListenerNode<() => void> | null;
         for( node = this.head; node; node = node.next )
         {
-            node.listener.call( node );
+            node.listener!.call( node );
             if( node.once )
             {
-                this.remove( node.listener );
+                this.remove( node.listener! );
             }
         }
         this.endDispatch();

--- a/src/ash/signals/Signal1.ts
+++ b/src/ash/signals/Signal1.ts
@@ -13,13 +13,13 @@ export class Signal1<T> extends SignalBase<( a:T ) => void>
     public dispatch( object:T ):void
     {
         this.startDispatch();
-        let node:ListenerNode<( a:T ) => void>;
+        let node:ListenerNode<( a:T ) => void> | null;
         for( node = this.head; node; node = node.next )
         {
-            node.listener.call( node, object );
+            node.listener!.call( node, object );
             if( node.once )
             {
-                this.remove( node.listener );
+                this.remove( node.listener! );
             }
         }
         this.endDispatch();

--- a/src/ash/signals/Signal2.ts
+++ b/src/ash/signals/Signal2.ts
@@ -13,13 +13,13 @@ export class Signal2<T1, T2> extends SignalBase<( a:T1, b:T2 ) => void>
     public dispatch( object1:T1, object2:T2 ):void
     {
         this.startDispatch();
-        let node:ListenerNode<( a:T1, b:T2 ) => void>;
+        let node:ListenerNode<( a:T1, b:T2 ) => void> | null;
         for( node = this.head; node; node = node.next )
         {
-            node.listener.call( node, object1, object2 );
+            node.listener!.call( node, object1, object2 );
             if( node.once )
             {
-                this.remove( node.listener );
+                this.remove( node.listener! );
             }
         }
         this.endDispatch();

--- a/src/ash/signals/Signal3.ts
+++ b/src/ash/signals/Signal3.ts
@@ -13,13 +13,13 @@ export class Signal3<T1, T2, T3> extends SignalBase<( a:T1, b:T2, c:T3 ) => void
     public dispatch( object1:T1, object2:T2, object3:T3 ):void
     {
         this.startDispatch();
-        let node:ListenerNode<( a:T1, b:T2, c:T3 ) => void>;
+        let node:ListenerNode<( a:T1, b:T2, c:T3 ) => void> | null;
         for( node = this.head; node; node = node.next )
         {
-            node.listener.call( node, object1, object2, object3 );
+            node.listener!.call( node, object1, object2, object3 );
             if( node.once )
             {
-                this.remove( node.listener );
+                this.remove( node.listener! );
             }
         }
         this.endDispatch();

--- a/src/ash/signals/SignalBase.ts
+++ b/src/ash/signals/SignalBase.ts
@@ -12,14 +12,14 @@ import { ListenerNodePool } from './ListenerNodePool';
 
 export class SignalBase<TListener>
 {
-    protected head:ListenerNode<TListener>;
-    protected tail:ListenerNode<TListener>;
+    protected head:ListenerNode<TListener> | null = null;
+    protected tail:ListenerNode<TListener> | null = null;
 
     private nodes:Dictionary<TListener, ListenerNode<TListener>>;
     private listenerNodePool:ListenerNodePool<TListener>;
-    private toAddHead:ListenerNode<TListener>;
-    private toAddTail:ListenerNode<TListener>;
-    private dispatching:boolean;
+    private toAddHead:ListenerNode<TListener> | null = null;
+    private toAddTail:ListenerNode<TListener> | null = null;
+    private dispatching:boolean = false;
     private _numListeners:number = 0;
 
     constructor()
@@ -45,7 +45,7 @@ export class SignalBase<TListener>
             }
             else
             {
-                this.tail.next = this.toAddHead;
+                this.tail!.next = this.toAddHead;
                 this.toAddHead.previous = this.tail;
                 this.tail = this.toAddTail;
             }
@@ -97,7 +97,7 @@ export class SignalBase<TListener>
             }
             else
             {
-                this.toAddTail.next = node;
+                this.toAddTail!.next = node;
                 node.previous = this.toAddTail;
                 this.toAddTail = node;
             }
@@ -110,7 +110,7 @@ export class SignalBase<TListener>
             }
             else
             {
-                this.tail.next = node;
+                this.tail!.next = node;
                 node.previous = this.tail;
                 this.tail = node;
             }
@@ -120,7 +120,7 @@ export class SignalBase<TListener>
 
     public remove( listener:TListener ):void
     {
-        let node:ListenerNode<TListener> = this.nodes.get( listener );
+        let node:ListenerNode<TListener> | null = this.nodes.get( listener );
         if( node )
         {
             if( this.head === node )
@@ -166,7 +166,7 @@ export class SignalBase<TListener>
         {
             let node:ListenerNode<TListener> = this.head;
             this.head = this.head.next;
-            this.nodes.remove( node.listener );
+            this.nodes.remove( node.listener! );
             this.listenerNodePool.dispose( node );
         }
         this.tail = null;

--- a/src/ash/tick/RAFTickProvider.ts
+++ b/src/ash/tick/RAFTickProvider.ts
@@ -3,9 +3,9 @@ import { ITickProvider } from './ITickProvider';
 
 export class RAFTickProvider extends Signal1<number> implements ITickProvider
 {
-    private rafId:number;
-    private previousTime:number;
-    public playing:boolean;
+    private rafId:number = 0;
+    private previousTime:number = 0;
+    public playing:boolean = false;
 
     constructor()
     {

--- a/src/ash/tools/ComponentPool.ts
+++ b/src/ash/tools/ComponentPool.ts
@@ -32,7 +32,7 @@ export class ComponentPool
 
         if( ComponentPool.pools.has( componentClass ) )
         {
-            return ComponentPool.pools.get( componentClass );
+            return ComponentPool.pools.get( componentClass )!;
         }
         else
         {
@@ -53,7 +53,7 @@ export class ComponentPool
         let pool:T[] = ComponentPool.getPool( componentClass );
         if( pool.length > 0 )
         {
-            return pool.pop();
+            return pool.pop()!;
         }
         else
         {

--- a/src/ash/tools/ListIteratingSystem.ts
+++ b/src/ash/tools/ListIteratingSystem.ts
@@ -28,10 +28,10 @@ import { System } from '../core/System';
 
 export abstract class ListIteratingSystem<TNode extends Node<any>> extends System
 {
-    protected nodeList:NodeList<TNode>;
+    protected nodeList:NodeList<TNode> | null = null;
     protected nodeClass:{ new():TNode };
-    protected nodeAdded:( node:Node<TNode> ) => void;
-    protected nodeRemoved:( node:Node<TNode> ) => void;
+    protected nodeAdded?:( node:Node<TNode> ) => void;
+    protected nodeRemoved?:( node:Node<TNode> ) => void;
 
     constructor( nodeClass:{ new():TNode } )
     {
@@ -45,7 +45,7 @@ export abstract class ListIteratingSystem<TNode extends Node<any>> extends Syste
         this.nodeList = engine.getNodeList<TNode>( this.nodeClass );
         if( this.nodeAdded )
         {
-            for( let node:Node<TNode> = this.nodeList.head; node; node = node.next )
+            for( let node:Node<TNode> | null = this.nodeList.head; node; node = node.next )
             {
                 this.nodeAdded( node );
             }
@@ -59,20 +59,23 @@ export abstract class ListIteratingSystem<TNode extends Node<any>> extends Syste
 
     public removeFromEngine( engine:Engine ):void
     {
+        if (!this.nodeList)
+            return;
+
         if( this.nodeAdded )
         {
-            this.nodeList.nodeAdded.remove( this.nodeAdded );
+            this.nodeList!.nodeAdded.remove( this.nodeAdded );
         }
         if( this.nodeRemoved )
         {
-            this.nodeList.nodeRemoved.remove( this.nodeRemoved );
+            this.nodeList!.nodeRemoved.remove( this.nodeRemoved );
         }
         this.nodeList = null;
     }
 
     public update( time:number ):void
     {
-        for( let node:Node<TNode> = this.nodeList.head; node; node = node.next )
+        for( let node:Node<TNode> | null = this.nodeList!.head; node; node = node.next )
         {
             this.updateNode( node, time );
         }

--- a/src/ash/tools/ListIteratingSystem.ts
+++ b/src/ash/tools/ListIteratingSystem.ts
@@ -59,9 +59,6 @@ export abstract class ListIteratingSystem<TNode extends Node<any>> extends Syste
 
     public removeFromEngine( engine:Engine ):void
     {
-        if (!this.nodeList)
-            return;
-
         if( this.nodeAdded )
         {
             this.nodeList!.nodeAdded.remove( this.nodeAdded );

--- a/tests/ComponentMatchingFamilyTests.spec.ts
+++ b/tests/ComponentMatchingFamilyTests.spec.ts
@@ -44,7 +44,7 @@ describe( 'ComponentMatchingFamily tests', () =>
     it( 'NodeList is initially empty', () =>
     {
         let nodes:NodeList<MockNode> = family.nodeList;
-        assert.isUndefined(nodes.head);
+        assert.isNull(nodes.head);
     } );
 
     it( 'matching Entity is added when access NodeList test 1', () =>
@@ -90,7 +90,7 @@ describe( 'ComponentMatchingFamily tests', () =>
         let entity:Entity = new Entity();
         family.newEntity( entity );
         let nodes:NodeList<MockNode> = family.nodeList;
-        assert.isUndefined( nodes.head );
+        assert.isNull( nodes.head );
     } );
 
     it( 'non matching Entity is not added when Component added', () =>
@@ -99,7 +99,7 @@ describe( 'ComponentMatchingFamily tests', () =>
         entity.add( new Matrix() );
         family.componentAddedToEntity( entity, Matrix );
         let nodes:NodeList<MockNode> = family.nodeList;
-        assert.isUndefined( nodes.head );
+        assert.isNull( nodes.head );
     } );
 
     it( 'Entity is removed when access NodeList first', () =>


### PR DESCRIPTION
As of TypeScript 2.7, when strict is enabled, any class properties not initialized in the constructor will be reported as an error when accessed unless we use definite assignment assertions. So I squashed these property initialization errors. Dealt with the strict null error checks as well.

I also changed the Map-like property types from Array to Object to deal with other strict related errors. I initially wanted to switch to ES6 Map but decided to stick with Object so as to not require the Map type definition and needing to polyfill Map when targeting ES5 browsers.

Finally I updated 3 unit tests to deal with the undefined to null type changes.